### PR TITLE
Fix unicode exception when joinning non-ascii channel name while starting a bot

### DIFF
--- a/ibid/plugins/core.py
+++ b/ibid/plugins/core.py
@@ -273,7 +273,7 @@ class UnicodeWarning(Processor):
             for value in object:
                 self.process(value)
         elif isinstance(object, str):
-            self.log.warning(u'Found a non-unicode string: %r' % object)
+            self.log.warning(u'Found a non-unicode string: %r', object)
 
 class ChannelTracker(Processor):
     priority = -1550

--- a/ibid/source/irc.py
+++ b/ibid/source/irc.py
@@ -89,7 +89,7 @@ class Ircbot(irc.IRCClient):
             self.mode(self.nickname, True, self.factory.modes.encode('utf-8'))
         self.ctcpMakeQuery(self.nickname, [('HOSTMASK', None)])
         for channel in self.factory.channels:
-            self.join(channel.encode('utf-8'))
+            self.join(channel)
         self.factory.log.info(u"Signed on")
 
         event = Event(self.factory.name, u'source')


### PR DESCRIPTION
When starting an ibid bot, ibid tries connecting to channel in config file.
But ibid throws unicode exception. Because, while joinning to channel after sign on, channel name is encoded twice.

This commit don't encode channel name when pass to join method.
Also this commit fix some typing error on unicodewarning class.
